### PR TITLE
Fix #13 : Separate logic for relative/absolute and root/subdirectory checks

### DIFF
--- a/src/main/java/com/parrot/docdown/data/RefLocator.java
+++ b/src/main/java/com/parrot/docdown/data/RefLocator.java
@@ -181,8 +181,12 @@ public class RefLocator extends RefProvider {
      */
     private ResourceDoc findResourceFile(String resourceFilePath, String markupDocContainer) {
         // relative path
-        if (!resourceFilePath.startsWith("/") && markupDocContainer != null) {
-            return projectRootDoc.getResourceDoc(markupDocContainer + "/" + resourceFilePath);
+        if (!resourceFilePath.startsWith("/")) {
+            if (markupDocContainer != null) {
+                return projectRootDoc.getResourceDoc(markupDocContainer + "/" + resourceFilePath);
+            } else {
+                return projectRootDoc.getResourceDoc(resourceFilePath);
+            }
         }
         // absolute path
         return projectRootDoc.getResourceDoc(resourceFilePath.substring(1));


### PR DESCRIPTION
Previously, relative path from root were considered absolute and the call to
substring(1) removed a part of the path instead of removing a leading "/"
Now relative and absolute path are handled separately.
